### PR TITLE
FISH-7166 Remove sun.security.pkcs11 from Import-Package header

### DIFF
--- a/smack-core/build.gradle
+++ b/smack-core/build.gradle
@@ -65,6 +65,7 @@ jar {
 	bundle {
 		bnd(
 				'DynamicImport-Package': '*',
+				'Import-Package': '!sun.security.*, *',
 		)
 	}
 }


### PR DESCRIPTION
As Payara doesn't export JDK modules, smack-core requiring 'sun.security.pkcs11' causes an OSGi error. Exclude it from the Import-Package header.